### PR TITLE
Added 'next_pane' and 'prev_pane' commands

### DIFF
--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -1,4 +1,6 @@
 [
     {"keys": ["ctrl+pagedown"], "command": "next_view_in_pane" },
     {"keys": ["ctrl+pageup"], "command": "prev_view_in_pane" },
+    {"keys": ["ctrl+shift+pagedown"], "command": "next_pane" },
+    {"keys": ["ctrl+shift+pageup"], "command": "prev_pane" },
 ]

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -1,4 +1,6 @@
 [
     {"keys": ["super+pagedown"], "command": "next_view_in_pane" },
     {"keys": ["super+pageup"], "command": "prev_view_in_pane" },
+    {"keys": ["super+shift+pagedown"], "command": "next_pane" },
+    {"keys": ["super+shift+pageup"], "command": "prev_pane" },
 ]

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -1,4 +1,6 @@
 [
     {"keys": ["ctrl+pagedown"], "command": "next_view_in_pane" },
     {"keys": ["ctrl+pageup"], "command": "prev_view_in_pane" },
+    {"keys": ["ctrl+shift+pagedown"], "command": "next_pane" },
+    {"keys": ["ctrl+shift+pageup"], "command": "prev_pane" },
 ]

--- a/pane_navigation.py
+++ b/pane_navigation.py
@@ -5,6 +5,20 @@ import sublime
 import sublime_plugin
 
 
+class NextPaneCommand(sublime_plugin.TextCommand):
+    """
+    Switch to the next group.
+    """
+    def run(self, view):
+        change_pane(self, view, 1)
+
+class PrevPaneCommand(sublime_plugin.TextCommand):
+    """
+    Switch to the previous group.
+    """
+    def run(self, view):
+        change_pane(self, view, -1)
+
 class NextViewInPaneCommand(sublime_plugin.TextCommand):
     """
     Switch to the next tab in the active pane.
@@ -20,6 +34,21 @@ class PrevViewInPaneCommand(sublime_plugin.TextCommand):
     """
     def run(self, view):
         change_tab_within_pane(self, view, -1)
+
+def change_pane(self, view, direction):
+    """
+    Jump through all panes
+    @param direction: 1 to navigate to next pane, -1 to navigate to
+                        previous pane
+    """
+    window = self.view.window()
+    group_index, view_index = window.get_view_index(window.active_view())
+    group_index = group_index + direction
+    if group_index < 0:
+        group_index = window.num_groups() - 1
+    elif group_index >= window.num_groups():
+        group_index = 0
+    window.focus_group(group_index)
 
 def change_tab_within_pane(self, view, direction):
     """


### PR DESCRIPTION
I was searching for a way to easily switch between panes. But I did not find a good plugin for that. Yours was the closest what I could find and realized that both ways of cycling through panes and tabs in panes complement each other.

So, thanks for creating that plugin!
Cheers